### PR TITLE
Update user sign up to allow tenant sign up

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -4,6 +4,7 @@
   ],
   "**/*.+(js|json)": [
     "npm run format",
-    "git add"
+    "git add",
+    "npm run test --bail --findRelatedTests"
   ]
 }

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -5,6 +5,6 @@
   "**/*.+(js|json)": [
     "npm run format",
     "git add",
-    "npm run test --bail --findRelatedTests"
+    "npm run test -- --bail --findRelatedTests --passWithNoTests"
   ]
 }

--- a/src/controllers/auth/index.js
+++ b/src/controllers/auth/index.js
@@ -2,7 +2,7 @@ const User = require('../../models/user')
 const firebase = require('../../lib/firebase')
 
 async function createUser(req, res) {
-  const {email, password} = req.body
+  const {email, password, type} = req.body
 
   try {
     // Create the user
@@ -14,7 +14,10 @@ async function createUser(req, res) {
       return res.status(400).json({message: 'Account not created'})
     }
 
-    await User.create({email, type: 'landlord'})
+    // Tenants should already be created in the system
+    if (type === 'landlord') {
+      await User.create({email, type})
+    }
 
     // Generate a JWT that can be used for future requests
     const token = await user.user.getIdToken()

--- a/src/docs/docs.js
+++ b/src/docs/docs.js
@@ -27,6 +27,7 @@ const tenantModel = {
 const registerInput = {
   email: 'example@gmail.com',
   password: 'badpassword',
+  type: 'landlord',
 }
 const registerReturn = {
   token:

--- a/src/docs/docs.js
+++ b/src/docs/docs.js
@@ -588,8 +588,8 @@ const docs = {
         },
       },
       properties: {
-        header: "Properties Table",
-        todo: "",
+        header: 'Properties Table',
+        todo: '',
         comment: "Status options may include: 'vacant' or 'occupied'", // changed from open, closed, occupied, forRent, or forSale
         table: {
           id: 'integer -> increment number assigned by database',
@@ -598,7 +598,7 @@ const docs = {
           city: 'string, not Null',
           state: 'string, not Null',
           zip: 'string, not Null',
-          status: 'enum ->, \'vacant\' or \'occupied\'',
+          status: "enum ->, 'vacant' or 'occupied'",
           image: 'string, can be null',
           landlordId: "integer -> references id in table 'users'",
         },
@@ -616,33 +616,34 @@ const docs = {
         },
       },
       workOrders: {
-        header: "Work Order Table",
-        todo: "",
-        comment: "",
+        header: 'Work Order Table',
+        todo: '',
+        comment: '',
         table: {
-          id: "integer -> increment number assigned by database", 
-          title: "string -> Work Order Title",
-          description: "text -> Description of the issue.",
-          type: "enum -> electrical, plumbing, HVAC, pest control, appliances",
-          startDate: "date -> from a timestamp",
+          id: 'integer -> increment number assigned by database',
+          title: 'string -> Work Order Title',
+          description: 'text -> Description of the issue.',
+          type: 'enum -> electrical, plumbing, HVAC, pest control, appliances',
+          startDate: 'date -> from a timestamp',
           endDate: "date -> can be 'null'",
           propertyId: "integer -> references id in table 'properties'",
-          createdBy: "integer -> references id in table 'users'"
-        }
+          createdBy: "integer -> references id in table 'users'",
+        },
       },
       woHistory: {
-        header: "Work Order History Table",
-        todo: "",
-        comment: "",
+        header: 'Work Order History Table',
+        todo: '',
+        comment: '',
         table: {
-          id: "integer -> increment number assigned by database", 
+          id: 'integer -> increment number assigned by database',
           woId: "integer -> references id in table 'workorders'",
-          status: 'enum -> new, acknowledged, assigned, sending, review, or closed', 
-          urgency: "enum -> low, medium, or high",
-          assignedTo: "string -> Name of Company task assigned to, can be null",
-          comment: "string -> comment if needed, may be null",
-          updatedate: "timestamp"
-        }
+          status:
+            'enum -> new, acknowledged, assigned, sending, review, or closed',
+          urgency: 'enum -> low, medium, or high',
+          assignedTo: 'string -> Name of Company task assigned to, can be null',
+          comment: 'string -> comment if needed, may be null',
+          updatedate: 'timestamp',
+        },
       },
       // other: {
       //   header: "Other Table",

--- a/src/lib/validate-auth-input.js
+++ b/src/lib/validate-auth-input.js
@@ -5,8 +5,8 @@ function isValidEmail(email) {
   return regex.test(email)
 }
 
-function validateAuthInput(req, res, next) {
-  const {email, password} = req.body
+const validateAuthInput = (requireType = false) => (req, res, next) => {
+  const {email, password, type} = req.body
 
   let errors = {}
 
@@ -20,6 +20,15 @@ function validateAuthInput(req, res, next) {
     errors.password = 'Password is required'
   } else if (password.length < 8) {
     errors.password = 'The password must be 8 characters long'
+  }
+
+  // Refactor this out at some point
+  if (requireType) {
+    if (!type) {
+      errors.type = 'type is required'
+    } else if (type !== 'landlord' && type !== 'tenant') {
+      errors.type = 'type must either be landlord or tenant'
+    }
   }
 
   if (Object.keys(errors).length > 0) {

--- a/src/middleware/__tests__/if-tenant-check-if-authorized.test.js
+++ b/src/middleware/__tests__/if-tenant-check-if-authorized.test.js
@@ -1,0 +1,57 @@
+const User = require('../../models/user')
+const Express = require('../../test-utils/express')
+const ifTenantCheckIfAuthorized = require('../if-tenant-check-if-authorized')
+
+jest.mock('../../models/user', () => {
+  return {
+    findByEmail: jest.fn(),
+  }
+})
+
+const createBody = input => ({
+  email: 'fake@gmail.com',
+  password: 'badpassword',
+  type: 'landlord',
+  ...input,
+})
+
+it('should call next if user is not a tenant', async () => {
+  const next = jest.fn()
+  const body = createBody()
+  const req = Express.mockRequest({body})
+  const res = Express.mockResponse()
+
+  await ifTenantCheckIfAuthorized(req, res, next)
+  expect(next).toHaveBeenCalledTimes(1)
+})
+
+it('should call next if user is tenant, and has been invited', async () => {
+  const next = jest.fn()
+  const body = createBody({type: 'tenant'})
+  const req = Express.mockRequest({body})
+  const res = Express.mockResponse()
+
+  // Skip the DB check and pretend the user is there
+  User.findByEmail.mockResolvedValueOnce(true)
+
+  await ifTenantCheckIfAuthorized(req, res, next)
+  expect(next).toHaveBeenCalledTimes(1)
+})
+
+it('should respond with a 401 if the user is a tenant, and they have not been invited', async () => {
+  const next = jest.fn()
+  const body = createBody({type: 'tenant'})
+  const req = Express.mockRequest({body})
+  const res = Express.mockResponse()
+
+  // Skip the DB check and pretend the user isn't there
+  User.findByEmail.mockResolvedValueOnce(false)
+
+  await ifTenantCheckIfAuthorized(req, res, next)
+  expect(res.status).toHaveBeenCalledTimes(1)
+  expect(res.status).toHaveBeenCalledWith(401)
+  expect(res.json).toHaveBeenCalledTimes(1)
+  expect(res.json).toHaveBeenCalledWith({
+    message: 'You must have an invitation from a landlord to join as a tenant',
+  })
+})

--- a/src/middleware/if-tenant-check-if-authorized.js
+++ b/src/middleware/if-tenant-check-if-authorized.js
@@ -1,0 +1,31 @@
+const User = require('../models/user')
+
+/*
+ * We want to limit tenants to only signing up if they have been added by a
+ * landlord. This middleware will serve as the spot to check that the tenant is
+ * authorized (invited) to sign up
+ * */
+const ifTenantCheckIfAuthorized = async (req, res, next) => {
+  if (req.body.type !== 'tenant') {
+    next()
+    return
+  }
+
+  try {
+    const tenant = await User.findByEmail(req.body.email)
+
+    if (!tenant) {
+      return res.status(401).json({
+        message:
+          'You must have an invitation from a landlord to join as a tenant',
+      })
+    }
+
+    next()
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({message: 'Something unexpected happened'})
+  }
+}
+
+module.exports = ifTenantCheckIfAuthorized

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -1,3 +1,4 @@
+const ifTenantCheckIfAuthorized = require('./if-tenant-check-if-authorized')
 const isValidTenantId = require('./is-valid-tenant-id')
 const isValidTenantIdParam = require('./is-valid-tenant-id-param')
 const isValidPropertyId = require('./is-valid-property-id')
@@ -6,6 +7,7 @@ const validateTenantHistoryInput = require('./validate-tenant-history-input')
 const requireLandlord = require('./require-landlord')
 
 module.exports = {
+  ifTenantCheckIfAuthorized,
   isValidTenantId,
   isValidTenantIdParam,
   isValidPropertyId,

--- a/src/routes/auth/auth.js
+++ b/src/routes/auth/auth.js
@@ -1,11 +1,18 @@
 const express = require('express')
 const validateAuthInput = require('../../lib/validate-auth-input')
+const {ifTenantCheckIfAuthorized} = require('../../middleware')
+
 const Auth = require('../../controllers/auth/')
 
 const router = express.Router()
 
-router.post('/register', validateAuthInput, Auth.createUser)
+router.post(
+  '/register',
+  validateAuthInput(true),
+  ifTenantCheckIfAuthorized,
+  Auth.createUser,
+)
 
-router.post('/login', validateAuthInput, Auth.login)
+router.post('/login', validateAuthInput(), Auth.login)
 
 module.exports = router

--- a/src/routes/auth/auth.test.js
+++ b/src/routes/auth/auth.test.js
@@ -27,6 +27,7 @@ const mockUserResponse = () => ({
 const createLogin = input => ({
   email: 'test@gmail.com',
   password: 'fakepassword',
+  type: 'landlord',
   ...input,
 })
 


### PR DESCRIPTION
This PR updates the sign up flow to allow both tenants and landlords to sign up.

Before a tenant can sign up they need to be added by their landlord. If they attempt to sign up before being added they will receive a 401.

This does introduce a breaking change because now the users `type` is required with the POST request to `/api/auth/register`. The type can be either `landlord` or `tenant`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts